### PR TITLE
Add deploy script

### DIFF
--- a/R/pin.R
+++ b/R/pin.R
@@ -1,19 +1,25 @@
-pin_if_board_exists <- function(board_connection, tagged_runs_meta, pin_name) {
+pin_if_board_exists <- function(
+    board_connection,  # connection to board on server
+    object_to_pin,  # will be meta or params_list
+    pin_name  # pin path, like user.name/pin-name
+) {
 
   is_board <- inherits(board_connection, c("pins_board_connect", "pins_board"))
 
   if (is_board) {
 
-    pin_exists <- pins::pin_exists(pin_name)
+    object_class <- class(object_to_pin)
+    if (object_class == "data.frame") file_type <- "csv"
+    if (object_class == "list") file_type <- "rds"
 
-      pins::pin_write(
-        board_connection,
-        x = tagged_runs_meta,
-        name = pin_name,
-        type = "csv",
-        versioned = TRUE
-      )
+    pins::pin_write(
+      board_connection,
+      x = object_to_pin,
+      name = pin_name,
+      type = file_type,
+      versioned = TRUE
+    )
 
-    }
+  }
 
 }

--- a/R/pin.R
+++ b/R/pin.R
@@ -1,0 +1,19 @@
+pin_if_board_exists <- function(board_connection, tagged_runs_meta, pin_name) {
+
+  is_board <- inherits(board_connection, c("pins_board_connect", "pins_board"))
+
+  if (is_board) {
+
+    pin_exists <- pins::pin_exists(pin_name)
+
+      pins::pin_write(
+        board_connection,
+        x = tagged_runs_meta,
+        name = pin_name,
+        type = "csv",
+        versioned = TRUE
+      )
+
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -26,15 +26,7 @@ See the [separate guidance](https://csucloudservices.sharepoint.com/:w:/r/sites/
 
 ## Redeploy
 
-If you make changes to the code in this repo, you can redeploy the report to Posit Connect like:
-
-``` r
-app_id <- rsconnect::deployments(".")[["appId"]]
-rsconnect::deployDoc(doc = "index.qmd", appId = app_id)
-```
-
-This checks for the 'app ID' in the rsconnect/ folder of your local project root, which is generated when you first deploy.
-Otherwise you can find the ID by opening the report from the Posit Connect 'Content' page and then looking for 'Content ID' in the Settings > Info panel of the interface.
+If you make changes to the code in this repo, you can redeploy the report to Posit Connect using the `deploy.R` script.
 
 ## Refresh
 

--- a/deploy.R
+++ b/deploy.R
@@ -1,0 +1,18 @@
+# Deploy to the current and new Posit Connect servers. The current server
+# (strategyunitwm.nhs.uk) will be switched off in May/June 2025 and the new
+# server (currently named su.mlcsu.org) will take its name.
+
+deploy <- function(server_name, app_id) {
+  rsconnect::deployDoc(
+    server = server_name,
+    appId = app_id,
+    doc = "index.qmd",
+    appName = "nhp_tagged_runs_params",
+    appTitle = "NHP: tagged-runs param-extraction report",
+    lint = FALSE,
+    forceUpdate = TRUE
+  )
+}
+
+deploy("connect.strategyunitwm.nhs.uk", 302)
+deploy("connect.su.mlcsu.org", 111)

--- a/deploy.R
+++ b/deploy.R
@@ -7,7 +7,7 @@ deploy <- function(server_name, app_id) {
     server = server_name,
     appId = app_id,
     doc = "index.qmd",
-    appName = "nhp_tagged_runs_params",
+    appName = "nhp_tagged_runs_params_report",
     appTitle = "NHP: tagged-runs param-extraction report",
     lint = FALSE,
     forceUpdate = TRUE
@@ -15,4 +15,4 @@ deploy <- function(server_name, app_id) {
 }
 
 deploy("connect.strategyunitwm.nhs.uk", 302)
-deploy("connect.su.mlcsu.org", 111)
+deploy("connect.su.mlcsu.org", 115)

--- a/index.qmd
+++ b/index.qmd
@@ -91,7 +91,7 @@ Pin this metadata so it's [available to use](https://connect.strategyunitwm.nhs.
 ```{r}
 #| label: pin-meta
 
-board <- pins::board_connect()
+board <- pins::board_connect(server = "https://connect.strategyunitwm.nhs.uk/")
 
 pins::pin_write(
   board,

--- a/index.qmd
+++ b/index.qmd
@@ -29,6 +29,7 @@ if (any(Sys.getenv(required_env_vars) == "")) {
 #| echo: false
 
 source("R/azure.R")
+source("R/pin.R")
 ```
 
 ## Purpose
@@ -49,8 +50,8 @@ In future, the params and results files will be stored separately, reducing the 
 
 You can access on Posit Connect (login- and permissions-dependent):
 
-* the params pin is matt.dray/nhp_tagged_runs_params
-* the metadata pin is matt.dray/nhp_tagged_runs_meta
+* the params pin at matt.dray/nhp_tagged_runs_params
+* the metadata pin at matt.dray/nhp_tagged_runs_meta
 
 ## Code
 
@@ -71,13 +72,15 @@ Try to connect to the pin boards on both servers (both are active in May 2025, t
 ```{r}
 #| label: board-connect
 
-possibly_connect <- purrr::possibly(pins::board_connect)
+possibly_connect <- purrr::possibly(pins::board_connect)  # NULL on failure
 
 board <- possibly_connect(server = "connect.strategyunitwm.nhs.uk")
 board_new <- possibly_connect(server = "connect.su.mlcsu.org")
 ```
 
 ### Metadata
+
+#### Data
 
 Files are stored in two separate containers: one with results, one with supporting information.
 
@@ -100,6 +103,8 @@ meta <- fetch_tagged_runs_meta(container_results, container_support)
 knitr::kable(meta)
 ```
 
+#### Pin
+
 Pin this metadata to both servers (if possible, depending on board availability). The `pin_if_board_exists()` function will only write the pin if a connection to the board has been successful.
 
 ```{r}
@@ -111,6 +116,8 @@ pin_if_board_exists(board_new, meta, "matt.dray/nhp_tagged_runs_meta")
 
 ### Params
 
+#### Data
+
 Given the metadata, read the corresponding `file` for each model run.
 
 ```{r}
@@ -120,11 +127,13 @@ params_list <- fetch_tagged_runs_params(meta, container_results)
 names(params_list)
 ```
 
+#### Pin
+
 Pin the params (if possible, depending on board availability).
 
 ```{r}
 #| label: pin-params
 
-pin_if_board_exists(board, meta, "matt.dray/nhp_tagged_runs_params")
-pin_if_board_exists(board_new, meta, "matt.dray/nhp_tagged_runs_params")
+pin_if_board_exists(board, params_list, "matt.dray/nhp_tagged_runs_params")
+pin_if_board_exists(board_new, params_list, "matt.dray/nhp_tagged_runs_params")
 ```

--- a/index.qmd
+++ b/index.qmd
@@ -33,7 +33,8 @@ source("R/azure.R")
 
 ## Purpose
 
-A Quarto document deployed to Posit Connect that runs on schedule. The source is in the [The-Strategy-Unit/nhp_tagged_runs_params](https://github.com/The-Strategy-Unit/nhp_tagged_runs_params) GitHub repo.
+A Quarto document deployed to Posit Connect that runs on schedule.
+The source is in the [The-Strategy-Unit/nhp_tagged_runs_params](https://github.com/The-Strategy-Unit/nhp_tagged_runs_params) GitHub repo.
 
 Generates and [pins](https://pins.rstudio.com/):
 
@@ -48,8 +49,8 @@ In future, the params and results files will be stored separately, reducing the 
 
 You can access on Posit Connect (login- and permissions-dependent):
 
-* the [params pin](https://connect.strategyunitwm.nhs.uk/content/32c7f642-e420-448d-b888-bf655fc8fa8b/)
-* the [metadata pin](https://connect.strategyunitwm.nhs.uk/content/811dbaf9-18fe-43aa-bf8e-06b0df66004e/)
+* the params pin is matt.dray/nhp_tagged_runs_params
+* the metadata pin is matt.dray/nhp_tagged_runs_meta
 
 ## Code
 
@@ -62,6 +63,19 @@ The steps in this report are to:
 1. Pin the params.
 
 The pins will not be updated if there is no new data.
+
+### Boards
+
+Try to connect to the pin boards on both servers (both are active in May 2025, though the new board will become the main one and eventually take the name of the old server).
+
+```{r}
+#| label: board-connect
+
+possibly_connect <- purrr::possibly(pins::board_connect)
+
+board <- possibly_connect(server = "connect.strategyunitwm.nhs.uk")
+board_new <- possibly_connect(server = "connect.su.mlcsu.org")
+```
 
 ### Metadata
 
@@ -86,20 +100,13 @@ meta <- fetch_tagged_runs_meta(container_results, container_support)
 knitr::kable(meta)
 ```
 
-Pin this metadata so it's [available to use](https://connect.strategyunitwm.nhs.uk/content/811dbaf9-18fe-43aa-bf8e-06b0df66004e/).
+Pin this metadata to both servers (if possible, depending on board availability). The `pin_if_board_exists()` function will only write the pin if a connection to the board has been successful.
 
 ```{r}
 #| label: pin-meta
-
-board <- pins::board_connect(server = "https://connect.strategyunitwm.nhs.uk/")
-
-pins::pin_write(
-  board,
-  x = meta,
-  name = "matt.dray/nhp_tagged_runs_meta", 
-  type = "csv",
-  versioned = TRUE
-)
+ 
+pin_if_board_exists(board, meta, "matt.dray/nhp_tagged_runs_meta")
+pin_if_board_exists(board_new, meta, "matt.dray/nhp_tagged_runs_meta")
 ```
 
 ### Params
@@ -113,16 +120,11 @@ params_list <- fetch_tagged_runs_params(meta, container_results)
 names(params_list)
 ```
 
-Pin the params so they're [available to use](https://connect.strategyunitwm.nhs.uk/content/32c7f642-e420-448d-b888-bf655fc8fa8b/).
+Pin the params (if possible, depending on board availability).
 
 ```{r}
 #| label: pin-params
 
-pins::pin_write(
-  board,
-  x = params_list,
-  name = "matt.dray/nhp_tagged_runs_params", 
-  type = "rds",
-  versioned = TRUE
-)
+pin_if_board_exists(board, meta, "matt.dray/nhp_tagged_runs_params")
+pin_if_board_exists(board_new, meta, "matt.dray/nhp_tagged_runs_params")
 ```


### PR DESCRIPTION
Close #11. See parent https://github.com/The-Strategy-Unit/data_science_planning/issues/71.

* Makes a `deploy()` function to allow the app to be deployed to both the old and new servers.
* Made the {pin} board server name explicit.
* Try to pin to both servers, prevent failure if a board is not found.
* I've checked that the deployment script works by deploying them already ([current](https://connect.strategyunitwm.nhs.uk/nhp/tagged-runs-params-report/) and [new](https://connect.su.mlcsu.org/nhp/tagged-runs-params-report/) servers).
* I've also checked that the generated pins work on both servers ([current meta](https://connect.strategyunitwm.nhs.uk/content/811dbaf9-18fe-43aa-bf8e-06b0df66004e/), [current params](https://connect.strategyunitwm.nhs.uk/connect/#/apps/d5e63213-d112-4555-a598-560fb7944b49/access), [new meta](https://connect.su.mlcsu.org/connect/#/apps/4688ee6d-0adb-437b-935c-3f2e99b45cbe/access), [new params](https://connect.su.mlcsu.org/connect/#/apps/4315e4ec-22a9-4687-9624-953b00d1b7f2/access)).

>[!NOTE]
> You won't need to render the Quarto doc to check it works. I'm saying this becuase I've already run the deploy.R script and it has successfully deployed to both servers and generated the pins as expected (see links above). It's best that you don't run it in case this causes a problem with the successful deployments (it shouldn't, but just in case, seeing as I'm away for the next couple of weeks as well).