### PR TITLE
Deploy to new server only

### DIFF
--- a/R/pin.R
+++ b/R/pin.R
@@ -9,8 +9,8 @@ pin_if_board_exists <- function(
   if (is_board) {
 
     object_class <- class(object_to_pin)
-    if (object_class == "data.frame") file_type <- "csv"
-    if (object_class == "list") file_type <- "rds"
+    if ("data.frame" %in% object_class) file_type <- "csv"
+    if ("list" %in% object_class) file_type <- "rds"
 
     pins::pin_write(
       board_connection,

--- a/deploy.R
+++ b/deploy.R
@@ -14,5 +14,4 @@ deploy <- function(server_name, app_id) {
   )
 }
 
-deploy("connect.strategyunitwm.nhs.uk", 302)
-deploy("connect.su.mlcsu.org", 115)
+deploy("connect.strategyunitwm.nhs.uk", 115)

--- a/index.qmd
+++ b/index.qmd
@@ -67,15 +67,12 @@ The pins will not be updated if there is no new data.
 
 ### Boards
 
-Try to connect to the pin boards on both servers (both are active in May 2025, though the new board will become the main one and eventually take the name of the old server).
+Connect to the server.
 
 ```{r}
 #| label: board-connect
 
-possibly_connect <- purrr::possibly(pins::board_connect)  # NULL on failure
-
-board <- possibly_connect(server = "connect.strategyunitwm.nhs.uk")
-board_new <- possibly_connect(server = "connect.su.mlcsu.org")
+board <- pins::board_connect(server = "https://connect.strategyunitwm.nhs.uk")
 ```
 
 ### Metadata
@@ -105,20 +102,19 @@ knitr::kable(meta)
 
 #### Pin
 
-Pin this metadata to both servers (if possible, depending on board availability). The `pin_if_board_exists()` function will only write the pin if a connection to the board has been successful.
+Pin this metadata to the server. The `pin_if_board_exists()` function will only write the pin if a connection to the board has been successful.
 
 ```{r}
 #| label: pin-meta
  
 pin_if_board_exists(board, meta, "matt.dray/nhp_tagged_runs_meta")
-pin_if_board_exists(board_new, meta, "matt.dray/nhp_tagged_runs_meta")
 ```
 
 ### Params
 
 #### Data
 
-Given the metadata, read the corresponding `file` for each model run.
+Given the metadata, read the corresponding `file` for each model run. This will take a short while.
 
 ```{r}
 #| label: get-params
@@ -135,5 +131,4 @@ Pin the params (if possible, depending on board availability).
 #| label: pin-params
 
 pin_if_board_exists(board, params_list, "matt.dray/nhp_tagged_runs_params")
-pin_if_board_exists(board_new, params_list, "matt.dray/nhp_tagged_runs_params")
 ```


### PR DESCRIPTION
Close #13.

* Deploy to new server only.
* Append 'https://' to server name (otherwise error).
* Re-form class check (otherwise error).

Already successfully deployed (and resulting pins correctly generated): https://connect.strategyunitwm.nhs.uk/nhp/tagged-runs-params-report/