### PR TITLE
Add NDG3 to run-stage tags

### DIFF
--- a/R/azure.R
+++ b/R/azure.R
@@ -94,13 +94,11 @@ fetch_tagged_runs_meta <- function(container_results, container_support) {
 
   # Run stages to keep/convert to factor levels (in order of preference for
   # selection). This set may expand in future as we add more NDG variants.
+  ndg_values <- c(2, 3, 1)  # preference order (2 is main, 3 and 1 secondary)
   run_stages <- c(
-    "final_report_ndg2",  # first level because it's preferred
-    "final_report_ndg1",
-    "intermediate_ndg2",
-    "intermediate_ndg1",
-    "initial_ndg2",
-    "initial_ndg1"
+    paste0("final_report_ndg", ndg_values),
+    paste0("intermediate_ndg", ndg_values),
+    paste0("initial_ndg", ndg_values)
   )
 
   latest_tagged_runs <- result_sets |>


### PR DESCRIPTION
Close #15.

* Added NDG3 to the list of `run_stage` values to look for.
* Added NDG variable `ndg_values` to refer once to order of NDG value preference.

Note that the whole file has been replaced (probably due to line-endings or something), but the only change is in the `run_stage` variable and new `ndg_values` variable. You can see this more easily by turning on the 'hide whitespace' option in the 'files changed' tab.

<img width="150" src="https://github.com/user-attachments/assets/171e7011-1dc8-4bf2-b1fa-c30a7bc65e61" />
